### PR TITLE
Upgrade react-router for scrollTop fix and make subject header titles a more reasonable size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": "0.13.3",
     "react-inline-css": "1.1.1",
     "react-redux": "0.2.2",
-    "react-router": "v1.0.0-beta2",
+    "react-router": "v1.0.0-beta3",
     "redux": "1.0.0-rc",
     "redux-devtools": "0.1.2",
     "serialize-javascript": "^1.0.0",

--- a/src/components/SubjectHeader.js
+++ b/src/components/SubjectHeader.js
@@ -5,12 +5,12 @@ import {Link} from 'react-router';
 const headerStyle = (domainSlug) => ({
   background: getSubjectColor(domainSlug),
   padding: "60px 40px 60px 40px"
-})
+});
 
 const subjectTitleStyle = {
   borderBottom: "1px solid rgba(255,255,255,0.5)",
   color: "#fff",
-  fontSize: "52px",
+  fontSize: "36px",
   fontWeight: "normal",
   lineHeight: 1,
   textRendering: "optimizeLegibility",
@@ -43,7 +43,7 @@ class SubjectHeader {
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     domainSlug: PropTypes.string.isRequired
-  }
+  };
 
   render() {
     const {ancestorTopicData, domainSlug, title, description} = this.props;


### PR DESCRIPTION
There was an issue in react-router where if you scrolled down and then clicked a link it wouldn't reset the scrollTop when it loaded the next page.  I upgraded the version of react-router to fix this.

Once I started seeing the titles I noticed that the font was too big and was causing bad wrapping in some of the titles so I fixed that as well.

Before:
<img width="432" alt="screen shot 2015-08-16 at 9 45 06 pm" src="https://cloud.githubusercontent.com/assets/1044413/9297669/48105170-4460-11e5-820c-6983d49fc0ac.png">

After:
<img width="432" alt="screen shot 2015-08-16 at 9 45 14 pm" src="https://cloud.githubusercontent.com/assets/1044413/9297670/4a5610fa-4460-11e5-84de-2642b038d018.png">
